### PR TITLE
Add serial helper

### DIFF
--- a/helpers/serial.js
+++ b/helpers/serial.js
@@ -1,0 +1,42 @@
+const Serial = {
+  port: undefined,
+  async init(baudRate=9600) {
+    if ("serial" in navigator) {
+      this.port = await navigator.serial.requestPort()
+      await this.port.open({ baudRate })
+      console.log("Serial started.")
+      Serial.start()
+    } else {
+      console.warning("Serial is not supported.")
+    }
+  },
+
+  async start(update) {
+    while (this.port.readable) {
+      const reader = this.port.readable.getReader()
+      try {
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) { break }
+
+          // decode serial message assuming all incoming messages are strings
+          let msg = ""
+          for (let i = 0; i < value.length; i++) {
+            msg = msg.concat(String.fromCharCode(value[i]))
+          }
+
+          // udpate state based on message
+          update(msg)
+        }
+      } catch (error) {
+        console.error(error)
+      } finally {
+        reader.releaseLock()
+      }
+    }
+
+    console.log("Serial stopped.")
+  }
+}
+
+export default Serial


### PR DESCRIPTION
Added a slightly modified version of the serial helper I created for Live Bike Reaction, allowing users to specify their own update function. This version still has the limitation that all incoming serial messages must be strings. Might make this more flexible later with config options for various serial message types.

Some example usage:
```
Serial.init(57600)
Serial.start((msg) => {
    state.acceleration = parseFloat(msg)
})
```